### PR TITLE
Add a menu for toggling horizontal and vertical snapping

### DIFF
--- a/screenlayout/gui.py
+++ b/screenlayout/gui.py
@@ -92,6 +92,10 @@ class Application:
                 <menuitem action="Zoom8" />
                 <menuitem action="Zoom16" />
             </menu>
+            <menu action="Snapping" name="Snapping">
+                <menuitem action="SnapHorizontally" />
+                <menuitem action="SnapVertically" />
+            </menu>
             <menu action="Outputs" name="Outputs">
                 <menuitem action="OutputsDummy" />
             </menu>
@@ -127,8 +131,9 @@ class Application:
 
             ("Quit", Gtk.STOCK_QUIT, None, None, None, Gtk.main_quit),
 
-
             ("View", None, _("_View")),
+
+            ("Snapping", None, _("_Snapping")),
 
             ("Outputs", None, _("_Outputs")),
             ("OutputsDummy", None, _("Dummy")),
@@ -141,6 +146,11 @@ class Application:
             ("Zoom8", None, _("1:8"), None, None, 8),
             ("Zoom16", None, _("1:16"), None, None, 16),
         ], 8, self.set_zoom)
+
+        actiongroup.add_toggle_actions([
+            ("SnapHorizontally", None, _("Snap horizontally"), None, None, self.set_horizontal_snap, True),
+            ("SnapVertically", None, _("Snap vertically"), None, None, self.set_vertical_snap, True),
+        ])
 
         window.connect('destroy', Gtk.main_quit)
 
@@ -181,6 +191,14 @@ class Application:
         self.gconf = None
 
     #################### actions ####################
+
+    @actioncallback
+    def set_horizontal_snap(self, value):
+        self.widget.horizontal_snap = value.get_active()
+
+    @actioncallback
+    def set_vertical_snap(self, value):
+        self.widget.vertical_snap = value.get_active()
 
     @actioncallback
     # don't use directly: state is not pushed back to action group.

--- a/screenlayout/snap.py
+++ b/screenlayout/snap.py
@@ -20,8 +20,10 @@ from .auxiliary import Position
 class Snap:
     """Snap-to-edges manager"""
 
-    def __init__(self, size, tolerance, positions):
+    def __init__(self, size, tolerance, positions, horizontal_snap=True, vertical_snap=True):
         self.tolerance = tolerance
+        self.horizontal_snap = horizontal_snap
+        self.vertical_snap = vertical_snap
 
         self.horizontal = set()
         self.vertical = set()
@@ -45,9 +47,9 @@ class Snap:
         horizontal = [y for y in self.horizontal if abs(
             y - position[1]) < self.tolerance]
 
-        if vertical:
+        if vertical and self.vertical_snap:
             position = Position((vertical[0], position[1]))
-        if horizontal:
+        if horizontal and self.horizontal_snap:
             position = Position((position[0], horizontal[0]))
 
         return position

--- a/screenlayout/widget.py
+++ b/screenlayout/widget.py
@@ -40,6 +40,8 @@ class ARandRWidget(Gtk.DrawingArea):
     _draggingoutput = None
     _draggingfrom = None
     _draggingsnap = None
+    horizontal_snap = True
+    vertical_snap = True
 
     __gsignals__ = {
         # 'expose-event':'override', # FIXME: still needed?
@@ -483,7 +485,9 @@ class ARandRWidget(Gtk.DrawingArea):
                 (virtual_state.position, virtual_state.size)
                 for (k, virtual_state) in self._xrandr.configuration.outputs.items()
                 if k != self._draggingoutput and virtual_state.active
-            ]
+            ],
+            widget.horizontal_snap,
+            widget.vertical_snap
         )
 
     def _dragmotion_cb(self, widget, context, x, y, time):  # pylint: disable=too-many-arguments


### PR DESCRIPTION
When adjusting monitor positions in relation to each other it is sometimes useful to be able to use very small increments of positioning. With the current function, the snapping is always turned on and the threshold for snapping might be too large to allow the flexibility required for the optimal monitor positioning scheme.

With this change, it is possible to to adjust monitors in relation to each other with far more presicion, while still keeping both sensible defaults (all snapping turned ON).

This is the first time I'm writing code for Gtk, so I just read the relevant documentation, and copied how menus are added. I don't think these options would fit well under other menus in the GUI, but I'm not sure.